### PR TITLE
Append "cwltool" to http User-Agent string

### DIFF
--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -8,6 +8,7 @@ import functools
 import io
 import logging
 import os
+import requests
 import signal
 import subprocess  # nosec
 import sys
@@ -985,7 +986,7 @@ def main(
     prov_log_handler: Optional[logging.StreamHandler[ProvOut]] = None
     global docker_exe
     try:
-        append_word_to_default_user_agent(f'cwltool/{versionfunc()}')
+        append_word_to_default_user_agent("cwltool")
         if args is None:
             if argsl is None:
                 argsl = sys.argv[1:]

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -176,7 +176,8 @@ def _signal_handler(signum: int, _: Any) -> None:
 
 def append_word_to_default_user_agent(word: str) -> None:
     original_function = requests.utils.default_user_agent;
-    requests.utils.default_user_agent = lambda *args: f'{original_function(*args)} {word}'
+    if not original_function().endswith(f' {word}'):
+        requests.utils.default_user_agent = lambda *args: f'{original_function(*args)} {word}'
 
 
 def generate_example_input(

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -175,9 +175,11 @@ def _signal_handler(signum: int, _: Any) -> None:
 
 
 def append_word_to_default_user_agent(word: str) -> None:
+    """Append the specified word to the requests http user agent string if it's not already there."""
     original_function = requests.utils.default_user_agent;
-    if not original_function().endswith(f' {word}'):
-        requests.utils.default_user_agent = lambda *args: f'{original_function(*args)} {word}'
+    suffix = f' {word}';
+    if not original_function().endswith(suffix):
+        requests.utils.default_user_agent = lambda *args: original_function(*args) + suffix
 
 
 def generate_example_input(

--- a/cwltool/main.py
+++ b/cwltool/main.py
@@ -173,6 +173,11 @@ def _signal_handler(signum: int, _: Any) -> None:
     sys.exit(signum)
 
 
+def append_word_to_default_user_agent(word: str) -> None:
+    original_function = requests.utils.default_user_agent;
+    requests.utils.default_user_agent = lambda *args: f'{original_function(*args)} {word}'
+
+
 def generate_example_input(
     inptype: Optional[CWLOutputType],
     default: Optional[CWLOutputType],
@@ -980,6 +985,7 @@ def main(
     prov_log_handler: Optional[logging.StreamHandler[ProvOut]] = None
     global docker_exe
     try:
+        append_word_to_default_user_agent(f'cwltool/{versionfunc()}')
         if args is None:
             if argsl is None:
                 argsl = sys.argv[1:]


### PR DESCRIPTION
Hi, my name is Steve, and I'm an engineer on the Dockstore team.  This PR appends the string "cwltool" to the `User-Agent` string of all cwltool HTTP requests issued via the `requests` package, so it looks like:
```
python-requests/2.31.0 cwltool
```

This PR would allow us to differentiate cwltool traffic from other Dockstore traffic that originates from the `requests` package.  After this change, we'd be able to track cwltool usage and handle its requests more appropriately.  For example, it'd be more feasible for us to filter a DOS attack and not affect cwltool traffic, or to tweak our webservice with a cwltool-specific accommodation.

